### PR TITLE
Improve restricted feedback in SubtaskGroup score type

### DIFF
--- a/cms/server/contest/static/cws_style.css
+++ b/cms/server/contest/static/cws_style.css
@@ -712,6 +712,10 @@ th.short {
     width: 100px;
 }
 
+#submission_detail table.testcase-list thead th.group {
+    width: 8%;
+}
+
 #submission_detail table.testcase-list tbody tr:not(.undefined) td.outcome {
     padding: 5px;
 }

--- a/cmscontrib/gerpythonformat/TaskConfig.py
+++ b/cmscontrib/gerpythonformat/TaskConfig.py
@@ -1224,9 +1224,9 @@ class TaskConfig(CommonConfig, Scope):
     @exported_function
     def feedback_level_restricted(self):
         """
-        In each public group, hide all test cases after the first one that
-        doesn't have outcome "Correct". Additionally, used time and memory are
-        hidden.
+        In each group that contributes to the official (private) score, show
+        only the first test case with minimum score. Additionally, used time
+        and memory are hidden in those groups.
 
         This is the default for all tasks.
 


### PR DESCRIPTION
Unless the feedback level is "full", we restrict the information shown to contestants as follows:

In each group, we show only the first test case with minimum score and we hide used time and memory. If all test cases in a group get full score, we instead only show a message "All correct".

This restriction doesn't apply to subtasks that don't contribute to the private (=official) score. Hence, we give full information about all sample test cases and about all test cases in detailed feedback subtasks.