### PR TITLE
Don't rerun checkers needlessly

### DIFF
--- a/cmscontrib/gerpythonformat/Executable.py
+++ b/cmscontrib/gerpythonformat/Executable.py
@@ -3,7 +3,7 @@
 
 # Programming contest management system
 # Copyright © 2013-2017 Tobias Lenz <t_lenz94@web.de>
-# Copyright © 2013-2014 Fabian Gundlach <320pointsguy@gmail.com>
+# Copyright © 2013-2022 Fabian Gundlach <320pointsguy@gmail.com>
 # Copyright © 2022 Manuel Gundlach <manuel.gundlach@gmail.com>
 #
 # This program is free software: you can redistribute it and/or modify

--- a/cmscontrib/gerpythonformat/Executable.py
+++ b/cmscontrib/gerpythonformat/Executable.py
@@ -194,9 +194,9 @@ class Executable(object):
         stderr = kwargs.pop("stderr", None)
         dependencies = kwargs.pop("dependencies", [])
 
-        self.run(args, kwargs, stdin=stdin, stdinstring=stdinstring,
-                 stdout=stdout, stderr=stderr,
-                 dependencies=dependencies)
+        return self.run(args, kwargs, stdin=stdin, stdinstring=stdinstring,
+                        stdout=stdout, stderr=stderr,
+                        dependencies=dependencies)
 
 
 class ParamsExecutable(Executable):
@@ -244,9 +244,9 @@ class ParamsExecutable(Executable):
             stdin = self.stdin
         if stdinstring is None:
             stdinstring = self.stdinstring
-        self.parent.run(args + self.args, k, stdin=stdin,
-                        stdinstring=stdinstring, stdout=stdout,
-                        stderr=stderr, dependencies=dependencies)
+        return self.parent.run(args + self.args, k, stdin=stdin,
+                               stdinstring=stdinstring, stdout=stdout,
+                               stderr=stderr, dependencies=dependencies)
 
     def __str__(self):
         return "{} with additional arguments {}" \
@@ -377,6 +377,7 @@ class CPPProgram(Executable):
                 "Error executing program {} with parameters {}"
                 .format(self.conf.short_path(self.wanted_path()),
                         str(list(args) + keyword_list(kwargs))))
+        return r
 
     def __str__(self):
         return self.conf.short_path(self.executable)

--- a/cmscontrib/gerpythonformat/TaskConfig.py
+++ b/cmscontrib/gerpythonformat/TaskConfig.py
@@ -1575,7 +1575,7 @@ class TaskConfig(CommonConfig, Scope):
             return
 
         if not isinstance(checker, CPPProgram):
-            raise Exception("Only checkers written in c++ are allowed.")
+            raise Exception("Only checkers written in C++ are allowed.")
 
         try:
             result = checker(outfile, stdin=infile,

--- a/cmscontrib/gerpythonformat/TaskConfig.py
+++ b/cmscontrib/gerpythonformat/TaskConfig.py
@@ -3,7 +3,7 @@
 
 # Programming contest management system
 # Copyright © 2013-2022 Tobias Lenz <t_lenz94@web.de>
-# Copyright © 2013-2016 Fabian Gundlach <320pointsguy@gmail.com>
+# Copyright © 2013-2022 Fabian Gundlach <320pointsguy@gmail.com>
 # Copyright © 2022 Manuel Gundlach <manuel.gundlach@gmail.com>
 #
 # This program is free software: you can redistribute it and/or modify

--- a/cmscontrib/gerpythonformat/TaskConfig.py
+++ b/cmscontrib/gerpythonformat/TaskConfig.py
@@ -28,7 +28,7 @@ from cmscontrib.gerpythonformat.Messenger import print_msg, print_block, header,
     remaining_line_length, indent, IndentManager
 from cmscontrib.gerpythonformat.CommonConfig import exported_function, CommonConfig
 from cmscontrib.gerpythonformat.Executable import ExitCodeException, \
-    InternalPython
+    InternalPython, CPPProgram
 from cmscontrib.gerpythonformat.ConstraintParser import ConstraintList, \
     merge_constraints, read_frequency, check_bounds
 from cmscommon.constants import SCORE_MODE_MAX_TOKENED_LAST, \
@@ -1574,15 +1574,15 @@ class TaskConfig(CommonConfig, Scope):
         if self.minimal:
             return
 
+        if not isinstance(checker, CPPProgram):
+            raise Exception("Only checkers written in c++ are allowed.")
+
         try:
-            checker_log = "checker-log.txt"
+            result = checker(outfile, stdin=infile,
+                             dependencies=[outfile])
 
-            checker(outfile, stdout=checker_log, stdin=infile,
-                    dependencies=[outfile])
-
-            with open(checker_log, 'r') as log_file:
-                log = log_file.read()
-                return json.loads(log) if len(log) > 0 else None
+            log = result.out
+            return json.loads(log) if len(log) > 0 else None
 
         except ExitCodeException:
             raise Exception(

--- a/cmscontrib/gerpythonformat/TaskConfig.py
+++ b/cmscontrib/gerpythonformat/TaskConfig.py
@@ -1471,6 +1471,8 @@ class TaskConfig(CommonConfig, Scope):
         """
         Register a test case checker for the "current" task, subtask or group.
 
+        The checker must be a CPPProgram.
+
         See :py:meth:`.Scope.add_checker`.
 
         """

--- a/docs/External contest formats.rst
+++ b/docs/External contest formats.rst
@@ -331,6 +331,8 @@ To check if your test cases are all valid, you can specify test case checkers us
 
 In the above example, :samp:`checker OUTPUT 0 < INPUT` would be run for all test cases and :samp:`checker OUTPUT 1 < INPUT` would be run for the test cases belonging to subtask 1.
 
+Checkers must be written in C++ and compiled with `compile(...)`. They mustn't write anything to stdout. On the other hand, stderr output is allowed and will be displayed to the user.
+
 Constraints
 ^^^^^^^^^^^
 


### PR DESCRIPTION
This should fix https://github.com/ioi-germany/cms/pull/20#discussion_r848508611 using solution proposal 1.

It only allows checkers written in C++, but I guess that was already assumed before. (?)

@t-lenz Please let me know if this looks okay.